### PR TITLE
fixed url encoding bug

### DIFF
--- a/angular-pinterest.js
+++ b/angular-pinterest.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * AngularJS directives for Pinterest buttons and widgets
  * @author Jason Watmore <jason@pointblankdevelopment.com.au> (https://www.pointblankdevelopment.com.au)
  * @version 1.1.0
@@ -66,9 +66,9 @@
 
                     element.html(
                         '<a href="//www.pinterest.com/pin/create/button/' +
-                            '?url=' + (scope.url || $location.absUrl()) +
-                            '&media=' + scope.media +
-                            '&description=' + scope.description + '" ' +
+                            '?url=' + encodeURIComponent(scope.url || $location.absUrl()) +
+                            '&media=' + encodeURIComponent(scope.media) +
+                            '&description=' + encodeURIComponent(scope.description) + '" ' +
                             'data-pin-do="buttonPin" ' +
                             'data-pin-config="' + (scope.config || '') + '" ' +
                             'data-pin-shape="' + (scope.shape || '') + '" ' + 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pinterest",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "authors": [
     "Jason Watmore <jason@pointblankdevelopment.com.au> (https://www.pointblankdevelopment.com.au/)"
   ],


### PR DESCRIPTION
I fixed a bug where url or media included query parameters were not being encoded properly, breaking the link url after parsePins was called.

I haven't minified it as i'm not sure what build scheme is being used for this.
